### PR TITLE
Remove warning from starter project blogpost

### DIFF
--- a/source/posts/clash-starter-project.html.markdown.erb
+++ b/source/posts/clash-starter-project.html.markdown.erb
@@ -41,9 +41,3 @@ an overview of the project and how to extend it. Alternatively, you can
 Happy Clashing!
 
 **Note**: Nix users might be interested in the [Clash Nix Starter Project](https://github.com/clash-lang/clash-starters/tree/main/simple-nix).
-
-**Note**: Due to [an upstream bug](https://gitlab.haskell.org/ghc/ghc/-/issues/18550),
-these instructions are currently broken on Windows Build 2004. This is expected
-to be fixed with the release of GHC 8.10.3. We will update the starter project
-and remove this message as soon as that happens. In the meantime, consider using
-WSL2 to run Clash.


### PR DESCRIPTION
Issues has been fixed by

 * https://github.com/clash-lang/stack-templates/pull/9